### PR TITLE
feat(XX-0425): migrate to new plugin format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 build
 dist
 cz_github_jira_conventional.egg-info
+.python-version

--- a/cz_github_jira_conventional.py
+++ b/cz_github_jira_conventional.py
@@ -272,6 +272,3 @@ class GithubJiraConventionalCz(BaseCommitizen):
 
 class InvalidAnswerError(CzException):
     ...
-
-
-discover_this = GithubJiraConventionalCz

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,9 @@ setup(
     description="Extend the commitizen tools to create conventional commits and README that link to Jira and GitHub.",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    entry_points={
+        "commitizen.plugin": [
+            "cz_github_jira_conventional = cz_github_jira_conventional:GithubJiraConventionalCz"
+        ]
+    },
 )


### PR DESCRIPTION
commitizen plugin format is changed from 3.0 and this plugin does not work at commitizen 3.X

BREAKING CHANGE:

this plugin will work from commitizen 3.X

Please refer https://commitizen-tools.github.io/commitizen/customization/