### PR TITLE
fix: Fix schema_pattern by placing exclamation mark regex after change type

### DIFF
--- a/cz_github_jira_conventional.py
+++ b/cz_github_jira_conventional.py
@@ -246,8 +246,8 @@ class GithubJiraConventionalCz(BaseCommitizen):
 
     def schema_pattern(self) -> str:
         PATTERN = (
-            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)"
-            r"(\(\S+\))?!?:(\s.*)"
+            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)?!?"
+            r"(\(\S+\)):(\s.*)"
         )
         return PATTERN
 


### PR DESCRIPTION
We are fixing the schema_pattern that was not allowing to use exclamation mark sign to mark a commit with Breaking Changes.

The following commit message, is considered a valid commit message for the plugin:
```
cz check --message "feat(ISSUE-ID)\!: Commit message"
Commit validation: successful!
```
However when creating changelog, this commit would not be identified as containing breaking changes.

The following commit message, is not considered a valid commit message for the plugin:
```
cz check --message "feat!(ISSUE-ID): Commit message" 
commit validation: failed!
please enter a commit message in the commitizen format.
commit "": "feat!(ISSUE-ID): Commit message"
pattern: (build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)(\(\S+\))?!?:(\s.*)
```

In order for the plugin to have a correct behaviour while identifying breaking changes according to the schema_pattern, we need to change the location of the `?!?` to be right after the change type.