### PR TITLE
release

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -5,4 +5,4 @@ commitizen:
   jira_prefix: XX-
   name: cz_github_jira_conventional
   tag_format: v$version
-  version: 2.0.0
+  version: 3.0.0

--- a/.cz.yaml
+++ b/.cz.yaml
@@ -1,7 +1,8 @@
+---
 commitizen:
   github_repo: apheris/cz_github_jira_conventional
   jira_base_url: https://myproject.atlassian.net
   jira_prefix: XX-
   name: cz_github_jira_conventional
   tag_format: v$version
-  version: 1.1.0
+  version: 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v3.0.0 (2024-06-12)
+
+### Fix
+
+- **[XX-9](https://myproject.atlassian.net/browse/XX-9)**: import of default commit parser [8923d](https://github.com//apheris/cz_github_jira_conventional/commit/8923d361adc983b0ad6260631530d0fb60aaef74)
+
 ## v2.0.0 (2023-06-15)
 
 ### Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0.0 (2023-06-15)
+
+### Feat
+
+- **[XX-0425](https://myproject.atlassian.net/browse/XX-0425)**: migrate to new plugin format [aaa35](https://github.com//apheris/cz_github_jira_conventional/commit/aaa35fbfbd95ee313916ac175f11efbf55635fab)
+- support custom github base URL [d1a32](https://github.com//apheris/cz_github_jira_conventional/commit/d1a322beabf402594d2a00abd9270e4c1c09d035)
+
 ## v1.1.0 (2022-07-26)
 
 ### Feat

--- a/cz_github_jira_conventional.py
+++ b/cz_github_jira_conventional.py
@@ -280,10 +280,11 @@ class GithubJiraConventionalCz(BaseCommitizen):
                     for issue_id in parsed_message["scope"].split(",")
                 ]
             )
-        parsed_message["message"] = (
-            f"{m} [{rev[:5]}]({self.github_base_url}/{self.github_repo}/commit/{commit.rev})"
-        )
+        parsed_message[
+            "message"
+        ] = f"{m} [{rev[:5]}]({self.github_base_url}/{self.github_repo}/commit/{commit.rev})"
         return parsed_message
 
 
-class InvalidAnswerError(CzException): ...
+class InvalidAnswerError(CzException):
+    ...

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="cz_github_jira_conventional",
-    version="2.0.0",
+    version="3.0.0",
     py_modules=["cz_github_jira_conventional"],
     author="Falko Krause, apheris AI GmbH",
     author_email="f.krause@apheris.com",
     license="MIT",
     url="https://github.com/apheris/cz-github-jira-conventional",
-    install_requires=["commitizen"],
+    install_requires=["commitizen^3.21.3"],
     description="Extend the commitizen tools to create conventional commits and README that link to Jira and GitHub.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="cz_github_jira_conventional",
-    version="1.1.0",
+    version="2.0.0",
     py_modules=["cz_github_jira_conventional"],
     author="Falko Krause, apheris AI GmbH",
     author_email="f.krause@apheris.com",


### PR DESCRIPTION
- **feat(XX-2815): allow choosing between multiple Jira projects**
- **bump: version 1.0.0 → 1.1.0**
- **feat: support custom github base URL**
- **feat(XX-0425): migrate to new plugin format**
- **fix(XX-9): import of default commit parser**
- **bump: version 1.1.0 → 2.0.0**
- **bump: version 2.0.0 → 3.0.0**
