### PR TITLE
fix version

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -5,4 +5,4 @@ commitizen:
   jira_prefix: XX-
   name: cz_github_jira_conventional
   tag_format: v$version
-  version: 3.0.0
+  version: 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v3.0.1 (2024-06-12)
+
+### Fix
+
+- fix the install_requires commitizen version [951b5](https://github.com//apheris/cz_github_jira_conventional/commit/951b508a3d12833cb69364ca92e16b5b9d724926)
+
 ## v3.0.0 (2024-06-12)
 
 ### Fix

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="f.krause@apheris.com",
     license="MIT",
     url="https://github.com/apheris/cz-github-jira-conventional",
-    install_requires=["commitizen^3.21.3"],
+    install_requires=["commitizen>=3.21.3"],
     description="Extend the commitizen tools to create conventional commits and README that link to Jira and GitHub.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- **feat(XX-2815): allow choosing between multiple Jira projects**
- **bump: version 1.0.0 → 1.1.0**
- **feat: support custom github base URL**
- **feat(XX-0425): migrate to new plugin format**
- **fix(XX-9): import of default commit parser**
- **bump: version 1.1.0 → 2.0.0**
- **bump: version 2.0.0 → 3.0.0**
- **chore: fix the install_requires commitizen version**
