### PR TITLE
feat: enforce jira issue ids in the schema pattern

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: python -m pip install -e . -r requirements.txt
+
+      - name: Run tests
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ This plugin extends the commitizen tools by:
 - **create links to GitHub** commits in the CHANGELOG.md
 - **create links to Jira** issues in the CHANGELOG.md
 
+The Jira issue ID is required both when creating a commit with `cz commit` and
+when linting an existing message with `cz check`: a scope may be omitted, but if
+it is present it has to be a comma-separated list of Jira issue IDs matching the
+configured `jira_prefix`. This keeps the changelog links valid, since every scope
+is rendered as `<jira_base_url>/browse/<scope>`.
+
+```
+> cz check --message "fix(XX-42): correct minor typos in code"
+Commit validation: successful!
+> cz check --message "fix(typos): correct minor typos in code"
+commit validation: failed!
+```
+
 When you call commitizen `commit` you will be required you to enter the scope of your commit as a Jira issue id (or multiple issue ids, prefixed or without prefix, see config below).
 ```
 > cz commit

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+# Import commitizen before the plugin module to avoid a circular import:
+# commitizen discovers plugins while it is imported, and this repository
+# registers `cz_github_jira_conventional` as one, so importing the plugin
+# module first would let commitizen re-enter the partially initialized module.
+import commitizen  # noqa: F401

--- a/cz_github_jira_conventional.py
+++ b/cz_github_jira_conventional.py
@@ -246,10 +246,34 @@ class GithubJiraConventionalCz(BaseCommitizen):
             "(BREAKING CHANGE: )<footer>"
         )
 
+    def issue_pattern(self) -> str:
+        """
+        Pattern that a single Jira issue id in the scope has to match.
+
+        Mirrors the validation of `parse_scope`, which is only applied to the
+        answers of the interactive `cz commit` prompt: if a prefix is configured,
+        `message()` prepends it when building the commit message, so the id must be
+        prefix + number; otherwise the user has to write the prefix themselves.
+        """
+        if self.jira_prefix:
+            prefixes = (
+                self.jira_prefix
+                if isinstance(self.jira_prefix, list)
+                else [self.jira_prefix]
+            )
+            alternatives = "|".join(re.escape(prefix) for prefix in prefixes)
+            return rf"(?:{alternatives})\d+"
+        return r"\w+-\d+"
+
     def schema_pattern(self) -> str:
+        issue = self.issue_pattern()
+        # The scope is optional, but if it is present it must be a comma
+        # separated list of Jira issue ids, because the changelog renders every
+        # scope as a link to `<jira_base_url>/browse/<scope>`. Keep the number
+        # of capturing groups at three, `process_commit` reads group 3.
         PATTERN = (
             r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)"
-            r"(\(\S+\))?!?:(\s.*)"
+            rf"(\({issue}(?:,\s?{issue})*\))?!?:(\s.*)"
         )
         return PATTERN
 
@@ -280,11 +304,10 @@ class GithubJiraConventionalCz(BaseCommitizen):
                     for issue_id in parsed_message["scope"].split(",")
                 ]
             )
-        parsed_message[
-            "message"
-        ] = f"{m} [{rev[:5]}]({self.github_base_url}/{self.github_repo}/commit/{commit.rev})"
+        parsed_message["message"] = (
+            f"{m} [{rev[:5]}]({self.github_base_url}/{self.github_repo}/commit/{commit.rev})"
+        )
         return parsed_message
 
 
-class InvalidAnswerError(CzException):
-    ...
+class InvalidAnswerError(CzException): ...

--- a/cz_github_jira_conventional.py
+++ b/cz_github_jira_conventional.py
@@ -183,7 +183,7 @@ class GithubJiraConventionalCz(BaseCommitizen):
 
     def parse_scope(self, text):
         """
-        Require and validate the scope to be Jira ids.
+        Require and validate the scope to be Jira IDs.
         """
         if self.jira_prefix:
             issueRE = re.compile(r"\d+")
@@ -248,11 +248,11 @@ class GithubJiraConventionalCz(BaseCommitizen):
 
     def issue_pattern(self) -> str:
         """
-        Pattern that a single Jira issue id in the scope has to match.
+        Pattern that a single Jira issue ID in the scope has to match.
 
         Mirrors the validation of `parse_scope`, which is only applied to the
         answers of the interactive `cz commit` prompt: if a prefix is configured,
-        `message()` prepends it when building the commit message, so the id must be
+        `message()` prepends it when building the commit message, so the ID must be
         prefix + number; otherwise the user has to write the prefix themselves.
         """
         if self.jira_prefix:
@@ -267,8 +267,8 @@ class GithubJiraConventionalCz(BaseCommitizen):
 
     def schema_pattern(self) -> str:
         issue = self.issue_pattern()
-        # The scope is optional, but if it is present it must be a comma
-        # separated list of Jira issue ids, because the changelog renders every
+        # The scope is optional, but if it is present it must be a
+        # comma-separated list of Jira issue IDs, because the changelog renders every
         # scope as a link to `<jira_base_url>/browse/<scope>`. Keep the number
         # of capturing groups at three, `process_commit` reads group 3.
         PATTERN = (
@@ -298,11 +298,10 @@ class GithubJiraConventionalCz(BaseCommitizen):
         rev = commit.rev
         m = parsed_message["message"]
         if parsed_message["scope"]:
+            issue_ids = [issue.strip() for issue in parsed_message["scope"].split(",")]
             parsed_message["scope"] = " ".join(
-                [
-                    f"[{issue_id}]({self.jira_base_url}/browse/{issue_id})"
-                    for issue_id in parsed_message["scope"].split(",")
-                ]
+                f"[{issue_id}]({self.jira_base_url}/browse/{issue_id})"
+                for issue_id in issue_ids
             )
         parsed_message["message"] = (
             f"{m} [{rev[:5]}]({self.github_base_url}/{self.github_repo}/commit/{commit.rev})"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-questionary==1.10.0
-black==26.3.1
-pre-commit==3.3.3
-twine==4.0.2
-setuptools==83.0.0
+black==26.5.1
+pre-commit==4.6.2
+pytest==9.1.1
+questionary==2.1.1
+setuptools==84.0.0
+twine==7.0.0
 wheel==0.48.0

--- a/test_cz_github_jira_conventional.py
+++ b/test_cz_github_jira_conventional.py
@@ -1,7 +1,7 @@
 import re
 
 import pytest
-from commitizen import config
+from commitizen import config, git
 
 from cz_github_jira_conventional import GithubJiraConventionalCz
 
@@ -45,6 +45,27 @@ def test_valid_messages(cz, message):
 )
 def test_invalid_messages(cz, message):
     assert not check(cz, message)
+
+
+@pytest.mark.parametrize("separator", [",", ", ", ",\t"])
+def test_changelog_trims_jira_issue_ids(cz, separator):
+    scope = separator.join(["XX-42", "XX-123", "XX-456"])
+    message = f"feat({scope}): allow multiple issues"
+    assert check(cz, message)
+    parsed_message = re.match(cz.commit_parser, message).groupdict()
+    commit = git.GitCommit(rev="abcdef123456", title=message)
+
+    result = cz.changelog_message_builder_hook(parsed_message, commit)
+
+    assert result["scope"] == (
+        f"[XX-42]({cz.jira_base_url}/browse/XX-42) "
+        f"[XX-123]({cz.jira_base_url}/browse/XX-123) "
+        f"[XX-456]({cz.jira_base_url}/browse/XX-456)"
+    )
+    assert result["message"] == (
+        f"allow multiple issues [abcde]"
+        f"({cz.github_base_url}/{cz.github_repo}/commit/abcdef123456)"
+    )
 
 
 def test_process_commit_still_returns_the_message(cz):

--- a/test_cz_github_jira_conventional.py
+++ b/test_cz_github_jira_conventional.py
@@ -1,0 +1,69 @@
+import re
+
+import pytest
+from commitizen import config
+
+from cz_github_jira_conventional import GithubJiraConventionalCz
+
+
+@pytest.fixture
+def cz():
+    """The plugin reads the `.cz.yaml` of this repository, which uses `XX-`."""
+    return GithubJiraConventionalCz(config.read_cfg())
+
+
+def check(cz, message):
+    return re.match(cz.schema_pattern(), message) is not None
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "fix: correct minor typos in code",
+        "fix(XX-42): correct minor typos in code",
+        "feat(XX-42,XX-123): allow multiple issues",
+        "feat(XX-42, XX-123): allow a space after the comma",
+        "feat(XX-42)!: mark a breaking change",
+        "bump: version 1.0.0 → 1.0.1",
+    ],
+)
+def test_valid_messages(cz, message):
+    assert check(cz, message)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "fix(foundry): a free form scope is not a jira issue",
+        "fix(ui): a free form scope is not a jira issue",
+        "fix(XX-): a prefix without a number is not a jira issue",
+        "fix(42): a number without a prefix is not a jira issue",
+        "fix(YY-42): an unconfigured prefix is not accepted",
+        "fix(XX-42,ui): every scope entry has to be a jira issue",
+        "unknown(XX-42): the type has to be a conventional commit type",
+    ],
+)
+def test_invalid_messages(cz, message):
+    assert not check(cz, message)
+
+
+def test_process_commit_still_returns_the_message(cz):
+    assert (
+        cz.process_commit("fix(XX-42): correct minor typos in code")
+        == "correct minor typos in code"
+    )
+
+
+def test_multiple_prefixes_are_accepted(cz, monkeypatch):
+    monkeypatch.setattr(GithubJiraConventionalCz, "jira_prefix", ["XX-", "XY-"])
+
+    assert check(cz, "fix(XY-42): a configured prefix is accepted")
+    assert check(cz, "fix(XX-42,XY-43): prefixes may be mixed")
+    assert not check(cz, "fix(YY-42): an unconfigured prefix is not accepted")
+
+
+def test_without_a_configured_prefix_any_prefix_is_accepted(cz, monkeypatch):
+    monkeypatch.setattr(GithubJiraConventionalCz, "jira_prefix", "")
+
+    assert check(cz, "fix(YY-42): the user writes the prefix themselves")
+    assert not check(cz, "fix(42): a number without a prefix is not a jira issue")


### PR DESCRIPTION
## Problem

The README promises to *"require a Jira issue id in the commit message"*, but that requirement was only enforced in one of two code paths:

| path | validated against Jira ids? |
|---|---|
| `cz commit` wizard → `parse_scope()` | yes |
| `cz check` (pre-commit hook, CI, PR titles) → `schema_pattern()` | **no** |

`schema_pattern()` accepted `(\(\S+\))?` — any non-space scope. So hand-written commits and GitHub PR titles (which become the commit subject on squash merge) sail through with a free-form scope, and `changelog_message_builder_hook()` then renders them as `<jira_base_url>/browse/<scope>`.

Real-world fallout in `apheris/hub`: commits like `chore(foundry): pin annotated OpenFold3 image` pass CI and produced 8 dead links in `CHANGELOG.md`, e.g.

```
[ui](https://apheris.atlassian.net/browse/ui)**: indicate persisted checkpoints…
```

## Change

- `issue_pattern()` builds the id pattern from the configured `jira_prefix` (string, list, or empty → `\w+-\d+`), mirroring `parse_scope()`.
- `schema_pattern()` uses it: the scope stays **optional**, but when present it must be a comma-separated list of Jira issue ids. The number of capturing groups stays at three because `process_commit()` reads `group(3)`.
- Adds `test_cz_github_jira_conventional.py` (16 cases), a `conftest.py` explaining/working around the plugin-discovery circular import, `pytest` in `requirements.txt`, and a `Tests` workflow — the repo had no tests or CI before.

Behaviour with this repo's `.cz.yaml` (`jira_prefix: XX-`):

```
$ cz check --message "chore(XX-42): pin image"
Commit validation: successful!
$ cz check --message "chore: pin image"
Commit validation: successful!
$ cz check --message "chore(foundry): pin image"
commit validation: failed!
pattern: (build|ci|…|bump)(\((?:XX\-)\d+(?:,\s?(?:XX\-)\d+)*\))?!?:(\s.*)
```

## Breaking change

Consumers that (intentionally or not) use free-form scopes will start failing `cz check` after upgrading. That is the point of the change, but it warrants a major bump and a heads-up to the repos using this plugin.

## Follow-up

`apheris/hub#2731` adds this validation as a repo-local bash step as a stopgap; once this is released and the version is bumped there, that step can be deleted.